### PR TITLE
Do not handle local data as a remote data.

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -6,6 +6,8 @@
 'use strict';
 var infix = '@2x';
 
+var DATA_URL_RE = /^data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/i;
+
 var ngRetina = angular.module('ngRetina', []).config(function($provide) {
   $provide.decorator('ngSrcDirective', ['$delegate', function($delegate) {
     $delegate[0].compile = function(element, attrs) {
@@ -32,6 +34,10 @@ ngRetina.directive('ngSrc', ['$window', '$http', function($window, $http) {
       return true;
     return ($window.matchMedia && $window.matchMedia(mediaQuery).matches);
   })();
+
+  function isDataURL(s) {
+    return !!s.match(DATA_URL_RE);
+  }
 
   function getHighResolutionURL(url) {
     var parts = url.split('.');
@@ -68,7 +74,7 @@ ngRetina.directive('ngSrc', ['$window', '$http', function($window, $http) {
     attrs.$observe('ngSrc', function(value) {
       if (!value)
         return;
-      if (isRetina && typeof $window.sessionStorage === 'object' && element[0].tagName === 'IMG') {
+      if (isRetina && typeof $window.sessionStorage === 'object' && element[0].tagName === 'IMG' && !isDataURL(value)) {
         set2xVariant(value);
       } else {
         setImgSrc(value);


### PR DESCRIPTION
- When set Data URL to the ng-src, it is trying to get the retina image.
  Since this is a local image, Chrome is complaining about CORS.

This patch is checking if the image is a local image, using a Regex and if
the regex match, it is handling the image as a normal image, instead of retina's
image.
