### PR TITLE
Improve file name parsing

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -35,11 +35,15 @@ ngRetina.directive('ngSrc', ['$window', '$http', function($window, $http) {
   })();
 
   function getHighResolutionURL(url) {
-    var parts = url.split('.');
-    if (parts.length < 2)
-      return url;
-    parts[parts.length - 2] += infix;
-    return parts.join('.');
+    var pathParts = url.split('/');
+    var file = pathParts.pop();
+    var fileParts = file.split('.');
+
+    if (fileParts.length < 2)
+      return url + infix;
+    fileParts[fileParts.length - 2] += infix;
+    pathParts.push(fileParts.join('.'));
+    return pathParts.join('/');
   }
 
   return function(scope, element, attrs) {


### PR DESCRIPTION
This patch improves parsing for images that do not have an extension. Without this patch the infix would be added to the domain, e.g. `www.example_2x.com/someFileWithoutExtension`. This patch changes it to append the infix to the full domain instead for such urls, e.g. `www.example.com/someFileWithoutExtension_2x`. 