### PR TITLE
Implemented url matching functionality

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -5,7 +5,8 @@
 (function(angular, undefined) {
 'use strict';
 var infix = '@2x',
-  data_url_regex = /^data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+  data_url_regex = /^data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
+  pattern = /.*/;
 
 var ngRetina = angular.module('ngRetina', []).config(function($provide) {
   $provide.decorator('ngSrcDirective', ['$delegate', function($delegate) {
@@ -19,6 +20,9 @@ var ngRetina = angular.module('ngRetina', []).config(function($provide) {
 ngRetina.provider('ngRetina', function() {
   this.setInfix = function(value) {
     infix = value;
+  };
+  this.setPattern = function(value) {
+    pattern = new RegExp(value);
   };
 
   this.$get = angular.noop;
@@ -35,6 +39,10 @@ ngRetina.directive('ngSrc', ['$window', '$http', function($window, $http) {
   })();
 
   function getHighResolutionURL(url) {
+    if (!pattern.test(url)) {
+      return url;
+    }
+
     var parts = url.split('.');
     if (parts.length < 2)
       return url;


### PR DESCRIPTION
When loading images from multiple source it can be desirable to whitelist or blacklist certain URIs to prevent `angular-retina` to try to load retina images from hosts that do not support retina images. This patch allows the user to provide a regular expression that urls should match to before angular-retina tries to load the retina versions.