### PR TITLE
Allow browserify to find this module's main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"description": "Replace AngularJS directive 'ng-src' by a version which supports Retina displays",
 	"version": "0.3.1",
 	"files": ["dist/angular-retina.js", "dist/angular-retina.min.js"],
+	"main": "dist/angular-retina",
 	"homepage": "https://github.com/jrief/angular-retina",
 	"author": {
 		"name": "Jacob Rief",


### PR DESCRIPTION
It either looks for a "main" entry in the package.json or looks for "index.js". Neither of which this module had.