### PR TITLE
Declared $provide as dependency of ngRetina module

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -7,14 +7,14 @@
 var infix = '@2x',
   data_url_regex = /^data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
-var ngRetina = angular.module('ngRetina', []).config(function($provide) {
+var ngRetina = angular.module('ngRetina', []).config(['$provide', function($provide) {
   $provide.decorator('ngSrcDirective', ['$delegate', function($delegate) {
     $delegate[0].compile = function(element, attrs) {
       // intentionally empty to override the built-in directive ng-src
     };
     return $delegate;
   }]);
-});
+}]);
 
 ngRetina.provider('ngRetina', function() {
   this.setInfix = function(value) {


### PR DESCRIPTION
Was getting this error when using Cassette to minify the script:

`"Uncaught Error: Unknown provider: n from ngRetina"`

