### PR TITLE
Allow older angular support for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,14 +12,14 @@
     "url": "git://github.com/jrief/angular-retina.git"
   },
   "dependencies": {
-    "angular": "~1.4.x"
+    "angular": ">= 1.2.x"
   },
   "ignore": [
     "lib",
     "test"
   ],
   "devDependencies": {
-    "angular-mocks": "~1.4.4",
-    "angular": "~1.4.4"
+    "angular-mocks": ">= 1.2.x",
+    "angular": ">= 1.2.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-retina",
   "description": "Replace AngularJS directive 'ng-src' by a version which supports Retina displays",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "build/angular-retina.js",
   "author": {
     "name": "Jacob Rief",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-retina",
   "description": "Replace AngularJS directive 'ng-src' by a version which supports Retina displays",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "files": [
     "dist/angular-retina.js",
     "dist/angular-retina.min.js"


### PR DESCRIPTION
Add back support to angular 1.2.x on bower.json
I forced 1.2.28 and ran all tests, seems working fine.

I also fixed the version bump. right now it is 0.3.2, but the tag one is broken. Check this out: https://github.com/jrief/angular-retina/blob/v0.3.2/bower.json