### PR TITLE
Handle QuotaExceededError exception noise

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -40,7 +40,7 @@
     this.$get = angular.noop;
   });
 
-  ngRetina.directive('ngSrc', ['$window', '$http', function($window, $http) {
+  ngRetina.directive('ngSrc', ['$window', '$http', '$log', function($window, $http, $log) {
     var msie = parseInt(((/msie (\d+)/.exec($window.navigator.userAgent.toLowerCase()) || [])[1]), 10);
     var isRetina = ((function() {
       var mediaQuery = '(-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), ' +
@@ -73,7 +73,11 @@
       function set2xVariant(imageUrl) {
         var imageUrl2x;
         if (angular.isUndefined(attrs.at2x)) {
-          imageUrl2x = $window.sessionStorage.getItem(imageUrl);
+          try {
+            imageUrl2x = $window.sessionStorage.getItem(imageUrl);
+          } catch (e) {
+            $log.warn('sessionStorage not supported');
+          }
         } else {
           imageUrl2x = attrs.at2x;
         }
@@ -83,11 +87,19 @@
           $http.head(imageUrl2x).
             success(function(data, status) {
             setImgSrc(imageUrl2x);
-            $window.sessionStorage.setItem(imageUrl, imageUrl2x);
+            try {
+              $window.sessionStorage.setItem(imageUrl, imageUrl2x);
+            } catch (e) {
+              $log.warn('sessionStorage not supported');
+            }
           })
           .error(function(data, status, headers, config) {
             setImgSrc(imageUrl);
-            $window.sessionStorage.setItem(imageUrl, imageUrl);
+            try {
+              $window.sessionStorage.setItem(imageUrl, imageUrl);
+            } catch (e) {
+              $log.warn('sessionStorage not supported');
+            }
           });
         } else {
           setImgSrc(imageUrl2x);


### PR DESCRIPTION
Sadly, private browsing on iOS Safari throws awful storage errors. Basically storage is not supported in this situation.

ngStorage has solved this same problem previously, with a slightly more elegant solution, but for the size of this codebase, I believe my hack is sufficient.
https://github.com/gsklee/ngStorage/blob/3cd5ffaff77bebda910b94ca2a657ac44f4aac79/ngStorage.js#L98-L130

Even the inclusion of `$log.warn` might be overkill.

![screen shot 2015-12-21 at 17 38 13](https://cloud.githubusercontent.com/assets/216917/11935715/a71c466c-a809-11e5-8bd0-5c0fd2ed27f1.png)
