### PR TITLE
Hide the image initially to prevent ugly squares

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -43,8 +43,10 @@ ngRetina.directive('ngSrc', ['$window', '$http', function($window, $http) {
   }
 
   return function(scope, element, attrs) {
+    element.css('opacity', 0);
     function setImgSrc(img_url) {
       attrs.$set('src', img_url);
+      element.css('opacity', 1);
       if (msie) element.prop('src', img_url);
     }
 


### PR DESCRIPTION
This prevents the ugly squares that appear while ng-retina is performing the initial OPTIONS request.

The image is simply made invisible until ng-retina has determined which URL to use, and calls `setImgSrc` to set it.

Personally I hate the flash of empty images. @jrief what do you think?