### PR TITLE
Fixes npm install installing an empty folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Replace AngularJS directive 'ng-src' by a version which supports Retina displays",
   "version": "0.3.12",
   "files": [
-    "dist/angular-retina.js",
-    "dist/angular-retina.min.js"
+    "build/angular-retina.js",
+    "build/angular-retina.min.js"
   ],
-  "main": "dist/angular-retina",
+  "main": "build/angular-retina",
   "homepage": "https://github.com/jrief/angular-retina",
   "author": {
     "name": "Jacob Rief",


### PR DESCRIPTION
Apparently the files array needs to have a reference to the files that are included in the NPM package.

Fixes: https://github.com/jrief/angular-retina/issues/44