### PR TITLE
Fixed race condition for fast-changing ng-src with multiple image urls.

### DIFF
--- a/lib/angular-retina.js
+++ b/lib/angular-retina.js
@@ -61,15 +61,6 @@
     }
 
     return function(scope, element, attrs) {
-      function setImgSrc(imageUrl) {
-        element.on('error', loadErrorHandler);
-
-        attrs.$set('src', imageUrl);
-        if (msie) {
-          element.prop('src', imageUrl);
-        }
-      }
-
       function getSessionStorageItem(imageUrl) {
         var item;
         try {
@@ -89,24 +80,40 @@
         }
       }
 
-      function set2xVariant(imageUrl) {
-        var imageUrl2x;
-        if (angular.isUndefined(attrs.at2x)) {
-          imageUrl2x = getSessionStorageItem(imageUrl);
-        } else {
-          imageUrl2x = attrs.at2x;
+      function get2xImageURL(imageUrl) {
+        return attrs.at2x || getSessionStorageItem(imageUrl);
+      }
+
+      function isCurrImgSrc(imgSrc) {
+        var currImgSrc = attrs.ngSrc;
+        var currImgSrc2x = get2xImageURL(currImgSrc);
+        return currImgSrc === imgSrc || currImgSrc2x === imgSrc;
+      }
+
+      function setImgSrc(imageUrl) {
+        if (!isCurrImgSrc(imageUrl)) return;
+
+        element.on('error', loadErrorHandler);
+
+        attrs.$set('src', imageUrl);
+        if (msie) {
+          element.prop('src', imageUrl);
         }
+      }
+
+      function set2xVariant(imageUrl) {
+        var imageUrl2x = get2xImageURL(imageUrl);
 
         if (!imageUrl2x) {
           imageUrl2x = getHighResolutionURL(imageUrl);
           $http.head(imageUrl2x).
             success(function(data, status) {
-            setImgSrc(imageUrl2x);
             setSessionStorageItem(imageUrl, imageUrl2x);
+            setImgSrc(imageUrl2x);
           })
           .error(function(data, status, headers, config) {
-            setImgSrc(imageUrl);
             setSessionStorageItem(imageUrl, imageUrl);
+            setImgSrc(imageUrl);
           });
         } else {
           setImgSrc(imageUrl2x);


### PR DESCRIPTION
It happens while changing **ng-src** rapidly with a serious of images, ex: 0001.png, 0002.png, ...and 0010.png, and the async $http.head() will result a race condition if some previous retina checking urls are returned lately.

For example, continuously changing the ng-src **from 0001.png to 0010.png**, it might happened that 0006@2x.png request is the latest response and be set to image src, however, it should be 0010@2x.png while the **ng-src** is 0010.png already.
